### PR TITLE
the problem of onIceCandidate

### DIFF
--- a/.gitreview
+++ b/.gitreview
@@ -1,5 +1,5 @@
 [gerrit]
-host=repository.kurento.com
+host=code.kurento.org
 port=12345
 project=kurento-tutorial-node.git
-defaultbranch=develop
+defaultbranch=release-5.1

--- a/kurento-chroma/package.json
+++ b/kurento-chroma/package.json
@@ -6,12 +6,13 @@
     "postinstall": "cd static && bower install"
   },
   "dependencies": {
-    "express": "~3.2.6",
-    "express-session": "~1.7.6",
-    "ws": "~0.4.32",
-    "minimist": "^1.1.0",
+    "cookie-parser": "^1.3.4",
+    "express": "~4.12.2",
+    "express-session": "~1.10.3",
     "kurento-client": "5.1.0",
-    "kurento-module-chroma": "1.0.3"
+    "kurento-module-chroma": "1.0.3",
+    "minimist": "^1.1.0",
+    "ws": "~0.7.1"
   },
   "devDependencies": {
     "bower": "^1.3.12"

--- a/kurento-chroma/server.js
+++ b/kurento-chroma/server.js
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2014 Kurento (http://kurento.org/)
+ * (C) Copyright 2014-2015 Kurento (http://kurento.org/)
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser General Public License
@@ -16,6 +16,7 @@
 var path = require('path');
 var url  = require('url');
 
+var cookieParser = require('cookie-parser')
 var express = require('express');
 var minimist = require('minimist');
 var session = require('express-session')
@@ -42,7 +43,7 @@ kurento.register(require('kurento-module-chroma'));
 /*
  * Management of sessions
  */
-app.use(express.cookieParser());
+app.use(cookieParser());
 
 var sessionHandler = session({
 	secret : 'none',
@@ -115,12 +116,12 @@ wss.on('connection', function(ws) {
 					}));
 				}
 				switch (type) {
-					case 'sdpAnswer': 
+					case 'sdpAnswer':
 						ws.send(JSON.stringify({
 							id : 'startResponse',
 							sdpAnswer : data
 						}));
-				}				
+				}
 			});
 			break;
 

--- a/kurento-chroma/static/bower.json
+++ b/kurento-chroma/static/bower.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "bootstrap": "~3.3.0",
     "ekko-lightbox": "~3.1.4",
-    "adapter.js": "kurento-chroma",
+    "adapter.js": "*",
     "kurento-utils": "5.1.0"
   }
 }

--- a/kurento-chroma/static/bower.json
+++ b/kurento-chroma/static/bower.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "bootstrap": "~3.3.0",
-    "ekko-lightbox": "~3.1.4",
+    "ekko-lightbox": "~3.2.3",
     "adapter.js": "*",
     "kurento-utils": "5.1.0"
   }

--- a/kurento-crowddetector/package.json
+++ b/kurento-crowddetector/package.json
@@ -6,9 +6,10 @@
     "postinstall": "cd static && bower install"
   },
   "dependencies": {
-    "express": "~3.2.6",
-    "express-session": "~1.7.6",
-    "ws": "~0.4.32",
+    "cookie-parser": "^1.3.4",
+    "express": "~4.12.2",
+    "express-session": "~1.10.3",
+    "ws": "~0.7.1",
     "minimist": "^1.1.0",
     "kurento-client": "5.1.0",
     "kurento-module-crowddetector": "1.0.1"

--- a/kurento-crowddetector/server.js
+++ b/kurento-crowddetector/server.js
@@ -20,7 +20,7 @@ var express  = require('express');
 var minimist = require('minimist');
 var session  = require('express-session')
 
-var WebSocketServer = require('ws');.Server
+var WebSocketServer = require('ws').Server;
 
 var kurento = require('kurento-client');
 

--- a/kurento-crowddetector/server.js
+++ b/kurento-crowddetector/server.js
@@ -16,6 +16,7 @@
 var path = require('path');
 var url  = require('url');
 
+var cookieParser = require('cookie-parser')
 var express  = require('express');
 var minimist = require('minimist');
 var session  = require('express-session')
@@ -40,7 +41,7 @@ kurento.register(require('kurento-module-crowddetector'));
 /*
  * Management of sessions
  */
-app.use(express.cookieParser());
+app.use(cookieParser());
 
 var sessionHandler = session({
 	secret : 'none',
@@ -114,31 +115,31 @@ wss.on('connection', function(ws) {
 					}));
 				}
 				switch (type) {
-					case 'sdpAnswer': 
+					case 'sdpAnswer':
 						ws.send(JSON.stringify({
 							id : 'startResponse',
 							sdpAnswer : data
 						}));
 						break;
-					case 'crowdDetectorDirection': 
+					case 'crowdDetectorDirection':
 						ws.send(JSON.stringify({
 							id : 'crowdDetectorDirection',
 							event_data : data
 						}));
 						break;
-					case 'crowdDetectorFluidity': 
+					case 'crowdDetectorFluidity':
 						ws.send(JSON.stringify({
 							id : 'crowdDetectorFluidity',
 							event_data : data
 						}));
 						break;
-					case 'crowdDetectorOccupancy': 
+					case 'crowdDetectorOccupancy':
 						ws.send(JSON.stringify({
 							id : 'crowdDetectorOccupancy',
 							event_data : data
 						}));
-						break;	
-				}				
+						break;
+				}
 			});
 			break;
 
@@ -248,7 +249,7 @@ function createMediaElements(pipeline, callback) {
 			return callback(error);
 		}
 
-		var _roi = {		
+		var _roi = {
 					'id' : 'roi1',
 					'points' : [{'x' : 0, 'y' : 0}, {'x' : 0.5, 'y' : 0}, {'x' : 0.5, 'y' : 0.5}, {'x' : 0, 'y' : 0.5}],
 					'regionOfInterestConfig' : {

--- a/kurento-crowddetector/static/bower.json
+++ b/kurento-crowddetector/static/bower.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "bootstrap": "~3.3.0",
     "ekko-lightbox": "~3.1.4",
-    "adapter.js": "kurento-chroma",
+    "adapter.js": "*",
     "kurento-utils": "5.1.0"
   }
 }

--- a/kurento-crowddetector/static/bower.json
+++ b/kurento-crowddetector/static/bower.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "bootstrap": "~3.3.0",
-    "ekko-lightbox": "~3.1.4",
+    "ekko-lightbox": "~3.2.3",
     "adapter.js": "*",
     "kurento-utils": "5.1.0"
   }

--- a/kurento-hello-world/package.json
+++ b/kurento-hello-world/package.json
@@ -6,8 +6,8 @@
     "postinstall": "cd static && bower install"
   },
   "dependencies": {
-    "body-parser": "~1.7.0",
-    "express": "~3.2.6",
+    "body-parser": "~1.12.0",
+    "express": "~4.12.2",
     "minimist": "^1.1.0",
     "kurento-client": "5.1.0"
   },

--- a/kurento-hello-world/static/bower.json
+++ b/kurento-hello-world/static/bower.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "bootstrap": "~3.3.0",
-    "ekko-lightbox": "~3.1.4",
+    "ekko-lightbox": "~3.2.3",
     "adapter.js": "*",
     "kurento-utils": "5.1.0"
   }

--- a/kurento-magic-mirror/package.json
+++ b/kurento-magic-mirror/package.json
@@ -6,11 +6,12 @@
     "postinstall": "cd static && bower install"
   },
   "dependencies": {
-    "express": "~3.2.6",
-    "express-session": "~1.7.6",
-    "ws": "~0.4.32",
+    "cookie-parser": "^1.3.4",
+    "express": "~4.12.2",
+    "express-session": "~1.10.3",
+    "kurento-client": "5.1.0",
     "minimist": "^1.1.0",
-    "kurento-client": "5.1.0"
+    "ws": "~0.7.1"
   },
   "devDependencies": {
     "bower": "^1.3.12"

--- a/kurento-magic-mirror/server.js
+++ b/kurento-magic-mirror/server.js
@@ -14,12 +14,16 @@
  */
 
 var path = require('path');
-var express = require('express');
-var session = require('express-session')
-var ws = require('ws');
-var minimist = require('minimist');
-var url = require('url');
+var url  = require('url');
+
+var cookieParser = require('cookie-parser')
+var express      = require('express');
+var session      = require('express-session')
+var minimist     = require('minimist');
+var ws           = require('ws');
+
 var kurento = require('kurento-client');
+
 
 var argv = minimist(process.argv.slice(2),
 {
@@ -35,7 +39,7 @@ var app = express();
 /*
  * Management of sessions
  */
-app.use(express.cookieParser());
+app.use(cookieParser());
 
 var sessionHandler = session({
 	secret : 'none',

--- a/kurento-magic-mirror/static/bower.json
+++ b/kurento-magic-mirror/static/bower.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "bootstrap": "~3.3.0",
-    "ekko-lightbox": "~3.1.4",
+    "ekko-lightbox": "~3.2.3",
     "adapter.js": "*",
     "kurento-utils": "5.1.0"
   }

--- a/kurento-one2many-call/package.json
+++ b/kurento-one2many-call/package.json
@@ -6,10 +6,10 @@
     "postinstall": "cd static && bower install"
   },
   "dependencies": {
-    "express": "~3.2.6",
+    "express": "~4.12.2",
     "kurento-client": "5.1.0",
     "minimist": "^1.1.0",
-    "ws": "~0.4.32"
+    "ws": "~0.7.1"
   },
   "devDependencies": {
     "bower": "^1.3.12"

--- a/kurento-one2many-call/static/bower.json
+++ b/kurento-one2many-call/static/bower.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "bootstrap": "~3.3.0",
-    "ekko-lightbox": "~3.1.4",
+    "ekko-lightbox": "~3.2.3",
     "adapter.js": "*",
     "kurento-utils": "5.1.0"
   }

--- a/kurento-one2many-with-plumbers/package.json
+++ b/kurento-one2many-with-plumbers/package.json
@@ -6,8 +6,8 @@
     "postinstall": "cd static && bower install"
   },
   "dependencies": {
-    "express": "~3.2.6",
-    "ws": "~0.4.32",
+    "express": "~4.12.2",
+    "ws": "~0.7.1",
     "minimist": "^1.1.0",
     "kurento-client": "5.1.0",
     "kurento-module-plumberendpoint": "1.0.1"

--- a/kurento-one2many-with-plumbers/static/bower.json
+++ b/kurento-one2many-with-plumbers/static/bower.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "bootstrap": "~3.3.0",
     "ekko-lightbox": "~3.1.4",
-    "adapter.js": "kurento-chroma",
+    "adapter.js": "*",
     "kurento-utils": "5.1.0"
   }
 }

--- a/kurento-one2many-with-plumbers/static/bower.json
+++ b/kurento-one2many-with-plumbers/static/bower.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "bootstrap": "~3.3.0",
-    "ekko-lightbox": "~3.1.4",
+    "ekko-lightbox": "~3.2.3",
     "adapter.js": "*",
     "kurento-utils": "5.1.0"
   }

--- a/kurento-one2one-call/package.json
+++ b/kurento-one2one-call/package.json
@@ -6,9 +6,9 @@
     "postinstall": "cd static && bower install"
   },
   "dependencies": {
-    "express": "~3.2.6",
+    "express": "~4.12.2",
     "minimist": "^1.1.0",
-    "ws": "~0.4.32",
+    "ws": "~0.7.1",
     "kurento-client": "5.1.0"
   },
   "devDependencies": {

--- a/kurento-one2one-call/static/bower.json
+++ b/kurento-one2one-call/static/bower.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "bootstrap": "~3.3.0",
-    "ekko-lightbox": "~3.1.4",
+    "ekko-lightbox": "~3.2.3",
     "draggabilly": "~1.1.1",
     "adapter.js": "*",
     "kurento-utils": "5.1.0"

--- a/kurento-platedetector/package.json
+++ b/kurento-platedetector/package.json
@@ -6,12 +6,13 @@
     "postinstall": "cd static && bower install"
   },
   "dependencies": {
-    "express": "~3.2.6",
-    "express-session": "~1.7.6",
-    "ws": "~0.4.32",
-    "minimist": "^1.1.0",
+    "cookie-parser": "^1.3.4",
+    "express": "~4.12.2",
+    "express-session": "~1.10.3",
     "kurento-client": "5.1.0",
-    "kurento-module-platedetector": "1.0.4"
+    "kurento-module-platedetector": "1.0.4",
+    "minimist": "^1.1.0",
+    "ws": "~0.7.1"
   },
   "devDependencies": {
     "bower": "^1.3.12"

--- a/kurento-platedetector/server.js
+++ b/kurento-platedetector/server.js
@@ -16,6 +16,7 @@
 var path = require('path');
 var url  = require('url');
 
+var cookieParser = require('cookie-parser')
 var express = require('express');
 var minimist = require('minimist');
 var session = require('express-session')
@@ -40,7 +41,7 @@ kurento.register(require('kurento-module-platedetector'));
 /*
  * Management of sessions
  */
-app.use(express.cookieParser());
+app.use(cookieParser());
 
 var sessionHandler = session({
 	secret : 'none',

--- a/kurento-platedetector/static/bower.json
+++ b/kurento-platedetector/static/bower.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "bootstrap": "~3.3.0",
     "ekko-lightbox": "~3.1.4",
-    "adapter.js": "kurento-chroma",
+    "adapter.js": "*",
     "kurento-utils": "5.1.0"
   }
 }

--- a/kurento-platedetector/static/bower.json
+++ b/kurento-platedetector/static/bower.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "bootstrap": "~3.3.0",
-    "ekko-lightbox": "~3.1.4",
+    "ekko-lightbox": "~3.2.3",
     "adapter.js": "*",
     "kurento-utils": "5.1.0"
   }

--- a/kurento-pointerdetector/package.json
+++ b/kurento-pointerdetector/package.json
@@ -6,12 +6,13 @@
     "postinstall": "cd static && bower install"
   },
   "dependencies": {
-    "express": "~3.2.6",
-    "express-session": "~1.7.6",
-    "ws": "~0.4.32",
-    "minimist": "^1.1.0",
+    "cookie-parser": "^1.3.4",
+    "express": "~4.12.2",
+    "express-session": "~1.10.3",
     "kurento-client": "^5.1.0",
-    "kurento-module-pointerdetector": "1.0.3"
+    "kurento-module-pointerdetector": "1.0.3",
+    "minimist": "^1.1.0",
+    "ws": "~0.7.1"
   },
   "devDependencies": {
     "bower": "^1.3.12"

--- a/kurento-pointerdetector/server.js
+++ b/kurento-pointerdetector/server.js
@@ -16,6 +16,7 @@
 var path = require('path');
 var url  = require('url');
 
+var cookieParser = require('cookie-parser')
 var express = require('express');
 var minimist = require('minimist');
 var session = require('express-session')
@@ -41,7 +42,7 @@ kurento.register(require('kurento-module-pointerdetector'));
 /*
  * Management of sessions
  */
-app.use(express.cookieParser());
+app.use(cookieParser());
 
 var sessionHandler = session({
 	secret : 'none',
@@ -116,32 +117,32 @@ wss.on('connection', function(ws) {
 					}));
 				}
 				switch (type) {
-					case 'sdpAnswer': 
+					case 'sdpAnswer':
 						ws.send(JSON.stringify({
 							id : 'startResponse',
 							sdpAnswer : data
 						}));
 						break;
-					case 'WindowIn': 
+					case 'WindowIn':
 						ws.send(JSON.stringify({
 							id : 'WindowIn',
 							roiId : data.windowId
 						}));
 						break;
-					case 'WindowOut': 
+					case 'WindowOut':
 						ws.send(JSON.stringify({
 							id : 'WindowOut',
 							roiId : data.windowId
 						}));
 						break;
-				}				
+				}
 			});
 			break;
 
 		case 'stop':
 			stop(sessionId);
 			break;
-		
+
 		case 'calibrate':
 			calibrate(sessionId);
 			break;
@@ -222,7 +223,7 @@ function start(sessionId, sdpOffer, callback) {
 							return callback(null, 'WindowOut', _data);
 						});
 
-						pointerDetector.addWindow({id: 'window0', height: 50, width:50, upperRightX: 500, upperRightY: 150}, 
+						pointerDetector.addWindow({id: 'window0', height: 50, width:50, upperRightX: 500, upperRightY: 150},
 							function(error) {
 							if (error) {
 								pipeline.release();
@@ -230,7 +231,7 @@ function start(sessionId, sdpOffer, callback) {
 							}
 						});
 
-						pointerDetector.addWindow({id: 'window1', height: 50, width:50, upperRightX: 500, upperRightY: 250}, 
+						pointerDetector.addWindow({id: 'window1', height: 50, width:50, upperRightX: 500, upperRightY: 250},
 							function(error) {
 							if (error) {
 								pipeline.release();

--- a/kurento-pointerdetector/static/bower.json
+++ b/kurento-pointerdetector/static/bower.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "bootstrap": "~3.3.0",
     "ekko-lightbox": "~3.1.4",
-    "adapter.js": "kurento-chroma",
+    "adapter.js": "*",
     "kurento-utils": "5.1.0"
   }
 }

--- a/kurento-pointerdetector/static/bower.json
+++ b/kurento-pointerdetector/static/bower.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "bootstrap": "~3.3.0",
-    "ekko-lightbox": "~3.1.4",
+    "ekko-lightbox": "~3.2.3",
     "adapter.js": "*",
     "kurento-utils": "5.1.0"
   }


### PR DESCRIPTION
function onIceCandidate(sessionId, _candidate) {
    var candidate = kurento.register.complexTypes.IceCandidate(_candidate);
    var user = userRegistry.getById(sessionId);

    if (pipelines[user.id] && pipelines[user.id].webRtcEndpoint && pipelines[user.id].webRtcEndpoint[user.id]) {
        var webRtcEndpoint = pipelines[user.id].webRtcEndpoint[user.id];
        webRtcEndpoint.addIceCandidate(candidate);
    }
    else {
        if (!candidatesQueue[user.id]) {
            candidatesQueue[user.id] = [];
        }
        candidatesQueue[sessionId].push(candidate);  // Question： why not use user.id?
    }
}

The value of user.id is equal to sessionId. However, the if statement block use 'user.id', the Question line should also use 'user.id' to improve the readability of this function.

