### PR TITLE
Adds heartbeat to prevent Websocket closing

### DIFF
--- a/kurento-one2many-call/server.js
+++ b/kurento-one2many-call/server.js
@@ -74,6 +74,13 @@ function nextUniqueId() {
  */
 wss.on('connection', function(ws) {
 
+   // prevent 1006 close on client 
+   var heartbeat = setInterval(function(){
+     // https://github.com/websockets/ws/blob/master/doc/ws.md#websocketpingdata-mask-callback
+     ws.ping();
+   }, 3000);
+
+	
 	var sessionId = nextUniqueId();
 	console.log('Connection received with sessionId ' + sessionId);
 
@@ -85,6 +92,7 @@ wss.on('connection', function(ws) {
     ws.on('close', function() {
         console.log('Connection ' + sessionId + ' closed');
         stop(sessionId);
+	clearInterval(heartbeat);
     });
 
     ws.on('message', function(_message) {


### PR DESCRIPTION
This change ensures Firefox (and others?) don't close connection when detected as idle with a CloseEvent of 1006. This is an opinionated change due to when using `ws.onclose` on the client. This is entirely committed for note and posterity.

Cheers