### PR TITLE
Fixes wss sessionHandler()

### DIFF
--- a/kurento-hello-world/package.json
+++ b/kurento-hello-world/package.json
@@ -6,7 +6,6 @@
     "postinstall": "cd static && bower install"
   },
   "dependencies": {
-    "cookie-parser": "^1.3.5",
     "express": "~4.12.4",
     "express-session": "~1.10.3",
     "minimist": "^1.1.1",

--- a/kurento-hello-world/server.js
+++ b/kurento-hello-world/server.js
@@ -17,7 +17,6 @@
 
 var path = require('path');
 var url = require('url');
-var cookieParser = require('cookie-parser')
 var express = require('express');
 var session = require('express-session')
 var minimist = require('minimist');
@@ -44,8 +43,6 @@ var app = express();
 /*
  * Management of sessions
  */
-app.use(cookieParser());
-
 var sessionHandler = session({
     secret : 'none',
     rolling : true,
@@ -80,14 +77,16 @@ var wss = new ws.Server({
 /*
  * Management of WebSocket messages
  */
-wss.on('connection', function(ws) {
+wss.on('connection', function (ws, request) {
     var sessionId = null;
-    var request = ws.upgradeReq;
     var response = {
         writeHead : {}
     };
 
-    sessionHandler(request, response, function(err) {
+    sessionHandler(request, response, function (err) {
+        if (err) {
+            console.error(err);
+        }
         sessionId = request.session.id;
         console.log('Connection received with sessionId ' + sessionId);
     });


### PR DESCRIPTION
In `kurento-hello-world` loading the page in the browser threw:
`TypeError: Cannot read property 'session' of undefined`
from `node_modules/express-session/index.js:181`
As per `https://github.com/websockets/ws/issues/1114`
ws after 3.0.0 no longer has `ws.upgradeReq`.
Workaround is to use the request object provided by the
callback of the `ws.on('connection')`
Also removes cookie-parser which is no longer needed
for this version of express-session.